### PR TITLE
feat(screen): add progress bar screen for save operation

### DIFF
--- a/src/pyinkr/dialogs.py
+++ b/src/pyinkr/dialogs.py
@@ -5,9 +5,9 @@ from typing import TYPE_CHECKING, override
 from textual import on
 from textual.app import ComposeResult
 from textual.binding import Binding
-from textual.containers import Container, Horizontal
+from textual.containers import Center, Container, Horizontal, Middle
 from textual.screen import ModalScreen
-from textual.widgets import Button, Footer, Header, Input
+from textual.widgets import Button, Footer, Header, Input, ProgressBar
 
 if TYPE_CHECKING:
     from typing import ClassVar
@@ -67,3 +67,55 @@ class EditScreen(ModalScreen[str | None]):
     def action_back(self) -> None:
         """Handles cancellation (button or escape key)."""
         self.dismiss(None)
+
+
+class ProgressBarScreen(ModalScreen[None]):
+    def __init__(
+        self,
+        title: str,
+        name: str | None = None,
+        id: str | None = None,
+        classes: str | None = None,
+    ) -> None:
+        """
+        Initialize the ProgressBarScreen.
+
+        Args:
+            title: The title to display at the top of the screen.
+            name: The name of the screen.
+            id: The ID of the screen.
+            classes: The CSS classes for the screen.
+        """
+        super().__init__(name=name, id=id, classes=classes)
+        self._title: str = title
+        self._total: float = 100.0
+
+    @override
+    def compose(self) -> ComposeResult:
+        """Compose the screen layout."""
+        yield Header()
+        with Container() as container:
+            container.border_title = self._title
+            with Center():
+                with Middle():
+                    yield ProgressBar(total=self._total)
+        yield Footer()
+
+    @property
+    def progress_bar(self) -> ProgressBar:
+        """Return the ProgressBar widget from the current screen."""
+        return self.query_one(ProgressBar)
+
+    def update(self, progress: int) -> None:
+        """Update the progress bar and close the screen when finished.
+
+        Args:
+            progress (int): Current progress value.
+
+        This method updates the ProgressBar widget with the given progress.
+        If the progress reaches or exceeds the total value, the screen
+        is dismissed automatically.
+        """
+        self.progress_bar.update(progress=progress)
+        if progress >= self._total:
+            self.dismiss(None)

--- a/src/pyinkr/screen.py
+++ b/src/pyinkr/screen.py
@@ -12,6 +12,7 @@ from textual.screen import Screen
 from textual.widgets import Checkbox, Footer, Header, TabbedContent, TabPane
 from textual_fspicker import FileOpen, FileSave
 
+from pyinkr.dialogs import ProgressBarScreen
 from pyinkr.widgets import InfoTree, ListTrack, NoticeWidget
 
 if TYPE_CHECKING:
@@ -62,7 +63,7 @@ class OpenScreen(Screen[tuple[type[MKVFile], type[Path]]]):
 
 class MkvManagScreen(Screen[None]):
     BINDINGS: ClassVar[list[BindingType]] = [
-        Binding("s", "save", "Save"),
+        Binding("s", "save", "Save", show=False),
         Binding("w", "toggle_overwrite", "Overwrite video", False),
         Binding("escape", "back_to_open", "Back To Open Screen", False),
     ]
@@ -88,20 +89,40 @@ class MkvManagScreen(Screen[None]):
         if (focused := self.focused) and self.focused.id:
             focused_id = f"#{focused.id}"
         self.app.manager, self.app.path = await self.app.push_screen_wait("Open")
-        await self.recompose()
+        self.refresh(layout=True, recompose=True)
         self.query_one(focused_id).focus()
 
     @work(exclusive=True)
     async def action_save(self) -> None:
-        """Save edttin video"""
+        """Save editing video"""
         if save_path := await self.app.push_screen_wait(
             FileSave(default_file=self.app.path, can_overwrite=self.can_overwrite)
         ):
+            if save_path == self.app.path:
+                return self.notify("You can not overwrite original file", severity="error")
+
             for i, checkbox in enumerate(self.query_one(ListTrack).query(Checkbox)):
                 if not checkbox.value:
                     self.app.manager.remove_track(i)
 
-            self.app.manager.mux(save_path)
+            try:
+                self.app.push_screen(ProgressBarScreen("Saveing..."))
+                self._mux(save_path)
+            except Exception as e:
+                self.notify(str(e), severity="error")
+                screens = self.app.screen_stack
+                if screens and isinstance(screens[-1], ProgressBarScreen):
+                    self.app.pop_screen()
+
+    @work(exclusive=True, thread=True)
+    async def _mux(self, save_path: Path) -> None:
+        def update(progress: int) -> None:
+            screen = self.app.screen_stack[-1]
+            if isinstance(screen, ProgressBarScreen):
+                self.app.call_from_thread(screen.update, progress)
+
+        self.app.manager.mux(save_path, progress_handler=update)
+        self.app.call_from_thread(self.notify, "Saved successfully", severity="information")
 
     def action_toggle_overwrite(self) -> None:
         self.can_overwrite ^= True

--- a/src/pyinkr/style.tcss
+++ b/src/pyinkr/style.tcss
@@ -56,3 +56,20 @@ NoticeWidget {
   content-align: center middle;
   color: $primary-lighten-3;
 }
+
+ProgressBarScreen {
+  align: center middle;
+
+  Container {
+    width: 95%;
+    height: 30%;
+    min-height: 10;
+
+    border: $border;
+    background: $panel;
+    border-title-color: $text;
+    border-title-background: $panel;
+    border-subtitle-color: $text;
+    border-subtitle-background: $error;
+  }
+}


### PR DESCRIPTION
Introduces a new ProgressBarScreen class to display a progress bar during the save operation. The screen is pushed onto the app's screen stack when the save operation is initiated, and the progress is updated asynchronously from the save operation. Includes error handling to notify the user if an exception occurs during the save.

close #9